### PR TITLE
Removed forced UTC timezone in TimeClock Sheet

### DIFF
--- a/time-clock/src/main/java/com/maxkeppeler/sheets/time_clock/ClockTimeSelector.kt
+++ b/time-clock/src/main/java/com/maxkeppeler/sheets/time_clock/ClockTimeSelector.kt
@@ -281,15 +281,9 @@ internal class ClockTimeSelector(
 
         val formatHours = if (is24HoursView) "HH" else "hh"
         val formatMinutes = "mm"
-        val timeZoneUTC = TimeZone.getTimeZone("etc/UTC")
 
-        val hours = SimpleDateFormat(formatHours).apply {
-            timeZone = timeZoneUTC
-        }.format(timeInMillis)
-
-        val minutes = SimpleDateFormat(formatMinutes).apply {
-            timeZone = timeZoneUTC
-        }.format(timeInMillis)
+        val hours = SimpleDateFormat(formatHours).format(timeInMillis)
+        val minutes = SimpleDateFormat(formatMinutes).format(timeInMillis)
 
         if (isAmTime(timeInMillis)) setAmActive()
         else setPmActive()


### PR DESCRIPTION
Forcing UTC for setTime() causes a number of problems for devices with a timezone that's not GMT+0:

- Timestamps entered have to be created from a "time at UTC" rather than a real timestamp created from Date(), Calendar, or elsewhere, otherwise the time will be off by X hours
- `isAmTime()` uses the device time zone, so even if we create a timestamp outside the module from  "5pm UTC" it may automatically select AM if "5PM UTC" is an AM time in the device timezone.

Both of these issues are resolved by removing the UTC timezone set.